### PR TITLE
update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 ﻿This project is built to benchmark C# asynchronous libraries against each other.
 
 To run the benchmarks on your machine:
-  1. Open `AsynchronousBenchmarks.sln` in Visual Studio 2019 or later, then build the solution.
-  2. Run `BenchmarkRunner.bat`.
+  1. Init git submodules by running `git submodule update --init --recursive`.
+  2. Build `ProtoPromise\ProtoPromise.sln` in `Release` mode.
+  3. Build `RSGPromise\C-Sharp-Promise.sln` in `Release` mode.
+  4. Build `UniTask\UniTask.NetCore.sln` in `Release` mode.
+  5. Build `AsynchronousBenchmarks.sln"` in `Release` mode.
+  6. Run `BenchmarkRunner.bat`.
     - Some benchmarks crash, causing windows to show a popup. You must close that popup for the rest of the benchmarks to continue.
-  3. See your results in the generated `BenchmarkDotNet.Artifacts` directory.
-
-
+  7. See your results in the generated `BenchmarkDotNet.Artifacts` directory.
 
 Here are the results after running on my 2010 desktop:
 


### PR DESCRIPTION
while trying to repro https://github.com/dotnet/BenchmarkDotNet/issues/1586 I've run into some issues with building the benchmarks...

I was surprised that git submodules are used instead of NuGet packages until I've hit https://github.com/Real-Serious-Games/C-Sharp-Promise/issues/84 ;)

I think it would be nice to mention what is required to be able to build the benchmarks