### PR TITLE
Benchmarks improvements

### DIFF
--- a/AsynchronousBenchmarks.sln
+++ b/AsynchronousBenchmarks.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 16.0.30621.155
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsynchronousBenchmarks", "AsynchronousBenchmarks\AsynchronousBenchmarks.csproj", "{9CDE46BB-E3BB-4794-9BEA-9BB75D579754}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProtoPromise", "ProtoPromise\Runtime\ProtoPromise.csproj", "{98F65B18-CEA2-443F-81E5-8CBEB9616005}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RSG.Promise", "RSGPromise\src\RSG.Promise.csproj", "{ECE70455-085F-40D6-939B-E9DF9DACFE2B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UniTask.NetCore", "UniTask\src\UniTask.NetCore\UniTask.NetCore.csproj", "{075B558B-9F7A-4AE7-960A-8055E98E7B98}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +21,18 @@ Global
 		{9CDE46BB-E3BB-4794-9BEA-9BB75D579754}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9CDE46BB-E3BB-4794-9BEA-9BB75D579754}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CDE46BB-E3BB-4794-9BEA-9BB75D579754}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98F65B18-CEA2-443F-81E5-8CBEB9616005}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98F65B18-CEA2-443F-81E5-8CBEB9616005}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98F65B18-CEA2-443F-81E5-8CBEB9616005}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98F65B18-CEA2-443F-81E5-8CBEB9616005}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECE70455-085F-40D6-939B-E9DF9DACFE2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECE70455-085F-40D6-939B-E9DF9DACFE2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECE70455-085F-40D6-939B-E9DF9DACFE2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECE70455-085F-40D6-939B-E9DF9DACFE2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{075B558B-9F7A-4AE7-960A-8055E98E7B98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{075B558B-9F7A-4AE7-960A-8055E98E7B98}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{075B558B-9F7A-4AE7-960A-8055E98E7B98}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{075B558B-9F7A-4AE7-960A-8055E98E7B98}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AsynchronousBenchmarks/AsynchronousBenchmarks.csproj
+++ b/AsynchronousBenchmarks/AsynchronousBenchmarks.csproj
@@ -14,23 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="ProtoPromise.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="ProtoPromise">
-      <HintPath>..\ProtoPromise\Runtime\bin\Release\netstandard2.0\ProtoPromise.dll</HintPath>
-    </Reference>
-    <Reference Include="RSG.Promise">
-      <HintPath>..\RSGPromise\src\bin\Release\netstandard2.0\RSG.Promise.dll</HintPath>
-    </Reference>
-    <Reference Include="UniTask">
-      <HintPath>..\UniTask\src\UniTask.NetCore\bin\Release\netstandard2.0\UniTask.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\ProtoPromise\Runtime\ProtoPromise.csproj" />
+    <ProjectReference Include="..\RSGPromise\src\RSG.Promise.csproj" />
+    <ProjectReference Include="..\UniTask\src\UniTask.NetCore\UniTask.NetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/AsynchronousBenchmarks/AsynchronousBenchmarks.csproj
+++ b/AsynchronousBenchmarks/AsynchronousBenchmarks.csproj
@@ -3,14 +3,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <DefineConstants>CSHARP_7_3_OR_NEWER;CSHARP_7_OR_LATER</DefineConstants>
+    <Progress>true</Progress>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;CSHARP_7_3_OR_NEWER;CSHARP_7_OR_LATER;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;CSHARP_7_3_OR_NEWER;CSHARP_7_OR_LATER;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
+  <PropertyGroup Condition="'$(Progress)' == 'false'">
+      <DefineConstants>$(DefineConstants);PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AsynchronousBenchmarks/Program.cs
+++ b/AsynchronousBenchmarks/Program.cs
@@ -1,9 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
-
-[assembly: SimpleJob(BenchmarkDotNet.Engines.RunStrategy.Throughput, BenchmarkDotNet.Jobs.RuntimeMoniker.Mono)]
-[assembly: SimpleJob(BenchmarkDotNet.Engines.RunStrategy.Throughput, BenchmarkDotNet.Jobs.RuntimeMoniker.CoreRt31)]
-[assembly: SimpleJob(BenchmarkDotNet.Engines.RunStrategy.Throughput, BenchmarkDotNet.Jobs.RuntimeMoniker.Net48)]
 
 namespace AsynchronousBenchmarks
 {
@@ -12,11 +10,33 @@ namespace AsynchronousBenchmarks
         public static readonly object obj = new object();
         public static readonly Vector4 vector = new Vector4(1f, -2.1f, -4f, 5.5f);
 
+        /// <summary>
+        /// to run specific benchmarks you must pass `--filter $glob`. Examples:
+        ///     * --filter '*' // runs all
+        ///     * --filter 'ContinuationBenchmarks' // runs only ContinuationBenchmarks
+        /// to run against specific runtimes you need to pass their target framework monikers using --runtimes. Examples:
+        ///     * --runtimes net472 mono netcoreapp31 corert31
+        /// to disable "Progress" modify the .csproj file and set it to false
+        /// Sample full command:
+        ///     * dotnet run -c Release -f net472 --filter * --runtimes net472 mono netcoreapp31 corert31
+        /// For more info please refer to https://benchmarkdotnet.org/articles/configs/toolchains.html#multiple-frameworks-support
+        /// </summary>
         public static void Main(string[] args)
         {
-            BenchmarkRunner.Run<ContinuationBenchmarks>();
-            BenchmarkRunner.Run<AwaitBenchmarks>();
-            BenchmarkRunner.Run<AsyncBenchmarks>();
+            // you can change it to Job.Default but Short just takes less time to run and is good for testing
+            var job = Job.ShortRun;
+
+#if PROTO_PROMISE_PROGRESS_DISABLE
+            // define custom MsBuildArgument that BenchmarkDotNet MUST pass to MsBuild when building the auto-generated projects
+            // and the referenced proejcts
+            job = job.WithArguments(new Argument[] { new MsBuildArgument("/p:Progress=false") });
+#endif
+            // tell BDN that this job should be extended by arguments passed from command line
+            job = job.AsDefault();
+
+            var config = DefaultConfig.Instance.AddJob(job);
+
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ﻿This project is built to benchmark C# asynchronous libraries against each other.
 
 To run the benchmarks on your machine:
-  1. Open `AsynchronousBenchmarks.sln` in Visual Studio 2019 or later, then build the solution.
-  2. Run `BenchmarkRunner.bat`.
-    - Some benchmarks crash, causing windows to show a popup. You must close that popup for the rest of the benchmarks to continue.
+  1. Init git submodules by running `git submodule update --init --recursive`
+Open `AsynchronousBenchmarks.sln` in Visual Studio 2019 or later, then build the solution.
+  2. `dotnet run -c Release -f net472 --project .\AsynchronousBenchmarks\AsynchronousBenchmarks.csproj  --filter '*' --runtimes net472 mono netcoreapp3.1`
   3. See your results in the generated `BenchmarkDotNet.Artifacts` directory.
 
 


### PR DESCRIPTION
This is a fix for https://github.com/dotnet/BenchmarkDotNet/issues/1586

Please see the explanation provided in https://github.com/dotnet/BenchmarkDotNet/issues/1586 and code comments for full explanation


@timcassell this PR is not a complete fix, you have to modify the `ProtoPromise.csproj` file as well:

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFrameworks>netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
    <RootNamespace>ProtoPromise</RootNamespace>
    <DefineConstants>CSHARP_7_3_OR_NEWER;CSHARP_7_OR_LATER</DefineConstants>
    <Progress>true</Progress>
  </PropertyGroup>

  <PropertyGroup Condition="'Progress' == 'false'">
    <DefineConstants>$(DefineConstants);PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
  </PropertyGroup>

  <ItemGroup>
    <Compile Remove="ProtoPromise\Promises\Unity\**" />
    <EmbeddedResource Remove="ProtoPromise\Promises\Unity\**" />
    <None Remove="ProtoPromise\Promises\Unity\**" />
  </ItemGroup>

  <ItemGroup>
    <Compile Remove="ProtoPromise\Utilities\AggregateException.cs" />
    <Compile Remove="ProtoPromise\Utilities\ValueTuple.cs" />
  </ItemGroup>

  <ItemGroup>
    <None Remove=".gitignore" />
    <None Remove="DeveloperNotes.txt" />
    <None Remove="ProtoPromise\ProtoPromise.asmdef" />
    <None Remove="ProtoPromise\ProtoPromise.asmdef.meta" />
  </ItemGroup>

</Project>
```